### PR TITLE
Fixed issue: *js-string-delimiter* was not properly forwarded in (lisp ....

### DIFF
--- a/src/non-cl.lisp
+++ b/src/non-cl.lisp
@@ -160,7 +160,8 @@
   ;; dynamic environment only, analogous to eval.
   `(ps-js:escape
     (with-output-to-string (*psw-stream*)
-      (let ((compile-expression? ,compile-expression?))
+      (let ((compile-expression? ,compile-expression?)
+	    (*js-string-delimiter* ,*js-string-delimiter*))
         (parenscript-print (ps-compile ,lisp-form) t)))))
 
 (defun lisp (x) x)


### PR DESCRIPTION
.....) forms.

For example: (ps-inline (alert (lisp "21")))

Would give "javascript:alert('21')" instead of "javascript:alert(\"21\")".