### PR TITLE
Fixed: empty-body clauses in COND should evaluate to the result of the test.

### DIFF
--- a/t/output-tests.lisp
+++ b/t/output-tests.lisp
@@ -3008,13 +3008,21 @@ return null;
 
 (test-ps-js empty-cond-clause
   (setf x (cond ((foo))))
-  "x = foo() ? null : null;")
+  "x = (function () { var testResult1 = foo(); return testResult1 ? testResult1 : null; })();")
 
 (test-ps-js empty-cond-clause1
   (setf x (cond ((foo) 123)
                 ((bar))
                 (t 456)))
-  "x = foo() ? 123 : (bar() ? null : 456);")
+  "x = foo() ? 123 :
+         (function () {
+            var testResult1 = bar();
+            if (testResult1) {
+              return testResult1;
+            } else {
+              if (true) { return 456; };
+            };
+          })();")
 
 (test-ps-js let-no-body
   (defun foo ()


### PR DESCRIPTION
http://www.lispworks.com/documentation/HyperSpec/Body/m_cond.htm says:

> cond {clause}\* => result\*
> clause ::= (test-form form\*) 
>
> [...]
> 
> Test-forms are evaluated one at a time in the order in which they are given
> in the argument list until a test-form is found that evaluates to true.
>
> **If there are no forms in that clause, the primary value of the test-form is**
> **returned by the cond form.**

So, e. g., if we (defun foo () #xF00), then (cond ((foo))) from the
empty-cond-clause test shall evaluate to #xF00.  The translated JavaScript
expression evaluates to null no matter what; and that's what I'm trying to fix
here.