### PR TITLE
Improved handling of declarations.

### DIFF
--- a/t/output-tests.lisp
+++ b/t/output-tests.lisp
@@ -2722,6 +2722,48 @@ try {
 };
 })();")
 
+(test-ps-js declare-special-let*
+  (let* ((*foo* 123) (*bar* (+ *foo* *bar*)))
+    (declare (special *foo* *bar*))
+    (blah))
+  "(function () {
+    var FOO_TMPSTACK1;
+    try {
+        FOO_TMPSTACK1 = FOO;
+        FOO = 123;
+        var BAR_TMPSTACK2;
+        try {
+            BAR_TMPSTACK2 = BAR;
+            BAR = FOO + BAR;
+            return blah();
+        } finally {
+            BAR = BAR_TMPSTACK2;
+        };
+    } finally {
+        FOO = FOO_TMPSTACK1;
+    };
+})();")
+
+(test-ps-js defun-multiple-declarations-around-docstring
+  (defun foo (x y)
+    (declare (ignorable x y))
+    (declare (integer x) (float y))
+    "Fooes X while barring Y."
+    (declare (special *foo*) (special *bar*))
+    (let ((*bar* (bar y)))
+      (funcall *foo* x)))
+  "/** Fooes X while barring Y. */
+function foo(x, y) {
+    var BAR_TMPSTACK1;
+    try {
+        BAR_TMPSTACK1 = BAR;
+        BAR = bar(y);
+        return FOO(x);
+    } finally {
+        BAR = BAR_TMPSTACK1;
+    };
+};")
+
 (test-ps-js macro-null-toplevel
   (progn
     (defmacro macro-null-toplevel ()


### PR DESCRIPTION
1. Named function bodies in Common Lisp may contain multiple DECLARE
   forms before or after the docstring (or even before *and* after).
   This feature is important for meta-programming by macros, and so
   PS should also support it.

2. Declarations should be allowed in PS forms whose Lisp namesakes
   allow them, to wit: in the macros WITH-SLOTS, MULTIPLE-VALUE-BIND,
   DO\*, DO, DOTIMES, DOLIST, DESTRUCTURING-BIND, LET\*, DEFUN,
   DEFSETF, and in the special forms LET, FLET, LABELS (letting out
   DEFMACRO, MACROLET, SYMBOL-MACROLET  who are not translated to
   JavaScript). Before the present commit, most of them didn't
   handle declarations correctly.

3. Individual DECLARE forms should be allowed to contain multiple
   declaration specifiers, in particular, multiple SPECIAL specifiers.
   WITH-DECLARATION-EFFECTS used to ignore SPECIALs after the first
   one.

4. This commit also introduces LOCALLY as PS form because it
   simplifies the implementation of stuff from (2).