### PR TITLE
Preserve "this" in implicit lambdas

### DIFF
--- a/src/compiler.lisp
+++ b/src/compiler.lisp
@@ -247,7 +247,7 @@ form, FORM, returns the new value for *compilation-level*."
           (expression-impl
            (apply expression-impl (cdr form)))
           ((member op *lambda-wrappable-statements*)
-           (compile-expression `((lambda () ,form))))
+           (compile-expression `(chain (lambda () ,form) (call this))))
           (t (error 'compile-expression-error :form form)))))
 
 (defun ps-compile (form)

--- a/src/lib/ps-loop.lisp
+++ b/src/lib/ps-loop.lisp
@@ -403,5 +403,5 @@
                     ,@(awhen (accum-var state) (list it))))
            (full `(block ,(name state) ,@(prologue-wrap (prologue state) main))))
       (if (accum-var state)
-          `((lambda () ,full))
+         `(chain (lambda () ,full) (call this))
           full))))

--- a/src/special-operators.lisp
+++ b/src/special-operators.lisp
@@ -418,7 +418,7 @@ Parenscript now implements implicit return, update your code! Things like (lambd
     (ps-gensym (symbol-name x))))
 
 (defun with-lambda-scope (body)
- (prog1 `((lambda () ,body))
+ (prog1 `(chain (lambda () ,body) (call this))
    (setf *vars-needing-to-be-declared* ())))
 
 (define-expression-operator let (bindings &body body)


### PR DESCRIPTION
This is a fix for Issue #17 

Note that unlike in my example for the issue, I use Function.prototype.call rather than Function.prototype.bind

It turns out that bind is only in IE9 or later, but call has existed since javascript 1.3 so should work everywhere.