### PR TITLE
Support for strict mode

### DIFF
--- a/src/compilation-interface.lisp
+++ b/src/compilation-interface.lisp
@@ -2,6 +2,8 @@
 
 (defparameter *js-target-version* "1.3")
 
+(defvar *strict-mode* nil)
+
 (defvar *parenscript-stream* nil)
 
 (defmacro ps (&body body)
@@ -77,6 +79,7 @@ if by ps*. If *parenscript-stream* is bound, writes the output to
     (let ((*compilation-level* :toplevel)
           (*readtable* *readtable*)
           (*package* *package*)
+          (*strict-mode* *strict-mode*)
           (*parenscript-stream* output-stream)
           (eof '#:eof))
       (loop for form = (funcall *ps-read-function* stream nil eof)

--- a/src/deprecated-interface.lisp
+++ b/src/deprecated-interface.lisp
@@ -104,6 +104,8 @@ is output to the OUTPUT-STREAM stream."
   (apply #'stringify things))
 
 (define-statement-operator with (expression &rest body)
+  (when *strict-mode*
+    (warn "`with' is not permitted in strict mode."))
   (warn-deprecated 'with '|LET or WITH-SLOTS|)
   `(ps-js:with ,(compile-expression expression)
      ,(compile-statement `(progn ,@body))))

--- a/src/function-definition.lisp
+++ b/src/function-definition.lisp
@@ -136,7 +136,9 @@ of (declare ...) forms, and the remaining body."
            (collapsed-body
             (collapse-function-return-blocks body))
            (suppress-values?
-            (find 'values (flatten body)))
+             (if *strict-mode*
+                 nil
+                 (find 'values (flatten body))))
            (*dynamic-return-tags*
             (append (mapcar (lambda (x) (cons x nil))
                             *function-block-names*)

--- a/src/macros.lisp
+++ b/src/macros.lisp
@@ -103,6 +103,15 @@
 (defpsmacro booleanp (x)
   `(string= (typeof ,x) "boolean"))
 
+(defpsmacro listp (x)
+  (if (vstring>= *js-target-version* "1.8.5")
+      `(chain *array (is-array ,x))
+      `(= (chain *object prototype to-string (call ,x))
+          "[object Array]")))
+
+(defpsmacro arrayp (x)
+  `(listp ,x))
+
 ;;; Data structures
 
 (defpsmacro make-array (&rest args)

--- a/src/non-cl.lisp
+++ b/src/non-cl.lisp
@@ -46,6 +46,7 @@
 (define-expression-operator create (&rest arrows)
   `(ps-js:object
     ,@(loop with allow-accessors = (vstring>= *js-target-version* "1.8.5")
+            with keys-seen = '()
             for (key val-expr) on arrows by #'cddr
             for (accessor . accessor-args) =
               (when (and allow-accessors
@@ -57,6 +58,10 @@
                             `((ps-js:get ,(second key)))))
                   (set (and (symbolp (third key)) (null (fourth key))
                             `((ps-js:set ,(second key)) ,(third key))))))
+            do (when *strict-mode*
+                 (if (member key keys-seen :test 'equal)
+                     (warn "Duplicated key in strict mode: ~a" key)
+                     (push key keys-seen)))
             collecting
               (if accessor
                   (list accessor accessor-args

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -19,6 +19,8 @@
 
    ;; compiler
    #:*js-target-version*
+   #:*strict-mode*
+   #:use-strict
    #:ps
    #:*parenscript-stream*
    #:ps-to-stream
@@ -303,5 +305,4 @@
    #:label
    #:f
    #:bind
-   #:bind*
-   ))
+   #:bind*))


### PR DESCRIPTION
This adds a `ps:*strict-mode*` flag which, when set, allows Parenscript to generate code that works in ECMA strict mode. Strict mode means no `with` and no `arguments.callee` or `function.caller` (so no multiple values).

The idea here isn't to prevent the programmer from writing code that violates strict mode, just to keep Parenscript from doing it behind the programmer's back.
