### PR TITLE
Update the Arithmetic and Boolean section of the reference documentation

### DIFF
--- a/docs/reference.html
+++ b/docs/reference.html
@@ -779,7 +779,7 @@
     <p>Operator forms are similar to function call forms, but have an
       operator as function name.</p>
 
-    <p>Please note that <code>=</code> is converted to <code>==</code> in
+    <p>Please note that <code>=</code> is converted to <code>===</code> in
       JavaScript. The <code>=</code> Parenscript operator is not the
       assignment operator.</p>
 

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -766,10 +766,8 @@
 
     <dl>
       <dt>&lt;operator&gt;</dt>
-      <dd>one of <code>*, /, %, +, -, <<, >>, >>>, < >, EQL,
-              ==, !=, =, ===, !==, &, ^, |, &&, AND, ||, OR</code>
+      <dd>one of <code>*, /, %, +, -, ASH, <, >, <=, >=, =, EQL, EQUAL, NOT, SETF, AND, OR</code>
       </dd>
-
       <dt>&lt;single-operator&gt;</dt>
       <dd>one of <code>INCF, DECF, ++, --, NOT, !</code></dd>
 
@@ -789,6 +787,21 @@
 
       <dt><code>(= 1 2)</code></dt>
       <dd><code>1 === 2;</code></dd>
+    </dl>
+
+    <p>The negation of equality operators are obtained by through <code>NOT</code>. For example:</p>
+
+    <dl>
+      <dt><code>(not (eql 1 2))</code></dt>
+      <dd><code>1 !== 2</code></dd>
+    </dl>
+
+    <p>The operators that in CL have variable arity convert into multiple calls
+    to the equivalent operators in JavaScript</p>
+
+    <dl>
+      <dt><code>(logxor 1 3 7 15)</code></dt>
+      <dd><code>1 ^ 3 ^ 7 ^ 15 </code></dd>
     </dl>
 
     <h2 id="section-math">Mathematical functions and constants</h2>


### PR DESCRIPTION
Following up on #29, update the documentation to reflect current parenscript behaviour. Also, to ease the publishing of the documentation, in the settings tab of the repository under github-pages, selecting sources master branch/docs folder will publish the html files in docs in the link pointed to by the updated readme. A couple of questions.
- Couldn't find find how to generate >>>, haven't dug into special-operators.lisp. Is there another way? The >>> doesn't appear to have a counter part in CL.
- Should the bit-wise symbols be removed from the reserved keywords?
