### PR TITLE
Added LISP-RAW special form.

### DIFF
--- a/docs/reference.html
+++ b/docs/reference.html
@@ -87,6 +87,7 @@
       <li>(<code id="ps-compile-stream">PS-COMPILE-STREAM</code> stream)</li>
       <li>(<code id="ps-compile-file">PS-COMPILE-FILE</code> file)</li>
       <li>(<code id="lisp">LISP</code> lisp-forms)</li>
+      <li>(<code id="lisp">LISP-RAW</code> lisp-forms)</li>
       <li>(<code id="symbol-to-js-string">SYMBOL-TO-JS-STRING</code> symbol)</li>
 
       <li><code id="*js-target-version*">*JS-TARGET-VERSION*</code></li>
@@ -151,7 +152,10 @@
       to <i>compile time</i>, where the effect is accomplished using
       macros) using the special form <code>LISP</code>. The form
       provided to <code>LISP</code> is evaluated, and its result is
-      compiled as though it were Parenscript code. For <code>PS</code>
+      compiled as though it were Parenscript code. The <code>LISP-RAW</code>
+      form acts as the <code>LISP</code> form, except that its results are
+      inserted directly into the javascript output without evaluation.
+      For <code>PS</code>
       and <code>PS-INLINE</code>, the Parenscript output code is
       generated at macro-expansion time, and the <code>LISP</code>
       statements are inserted inline into the output and have access

--- a/src/non-cl.lisp
+++ b/src/non-cl.lisp
@@ -186,6 +186,12 @@
 
 (defun lisp (x) x)
 
+(define-expression-operator lisp-raw (lisp-form)
+  `(ps-js:escape
+    ,lisp-form))
+
+(defun lisp-raw (x) x)
+
 (defpsmacro undefined (x)
   `(eql "undefined" (typeof ,x)))
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -242,6 +242,7 @@
 
    ;; lisp eval
    #:lisp
+   #:lisp-raw
 
    ;; js object stuff
    #:delete
@@ -303,5 +304,4 @@
    #:label
    #:f
    #:bind
-   #:bind*
-   ))
+   #:bind*))

--- a/t/output-tests.lisp
+++ b/t/output-tests.lisp
@@ -1790,6 +1790,12 @@ return foo(1);
                  (declare (special foo))
                  (ps (+ 1 (lisp foo)))))))
 
+(test ps-lisp-raw-embed
+  (is (string= "1 + 3;" (ps (lisp-raw "1 + 3")))))
+
+(test ps*-lisp-raw-embed
+  (is (string= "1 + 3;" (ps* '(lisp-raw "1 + 3")))))
+
 (test-ps-js nested-if-expressions1
   (defun foo ()
     (return-from foo (if (if x y z) a b)))


### PR DESCRIPTION
Allows the insertion of raw strings into output javascript expressions. Useful for generating javascript with 3rd party tools, as in [this example](http://stackoverflow.com/questions/30415081/is-there-a-way-to-insert-raw-javascript-in-parenscript-code)