### PR TITLE
Move *ps-gensym-counter* to stop compile warning

### DIFF
--- a/src/compiler.lisp
+++ b/src/compiler.lisp
@@ -216,6 +216,8 @@ CL environment)."
 
 ;;; lambda wrapping
 
+(defvar *ps-gensym-counter* 0)
+
 (defvar this-in-lambda-wrapped-form? nil)
 
 (defun lambda-wrap (form)
@@ -297,8 +299,6 @@ form, FORM, returns the new value for *compilation-level*."
 (defun compile-expression (form)
   (let ((compile-expression? t))
     (ps-compile form)))
-
-(defvar *ps-gensym-counter* 0)
 
 (defun ps-gensym (&optional (prefix-or-counter "_JS"))
   (assert (or (stringp prefix-or-counter) (integerp prefix-or-counter)))


### PR DESCRIPTION
This variable is used by lambda-wrap, but is defined long after.  This generates a compiler warning on SBCL.