### PR TITLE
ES classes, arrow functions, and a bug. Oh My!

### DIFF
--- a/src/compiler.lisp
+++ b/src/compiler.lisp
@@ -218,6 +218,8 @@ CL environment)."
 
 (defvar this-in-lambda-wrapped-form? nil)
 
+(defvar *ps-gensym-counter* 0)
+
 (defun lambda-wrap (form)
   (let ((this-in-lambda-wrapped-form? :query)
 	(*ps-gensym-counter* *ps-gensym-counter*))
@@ -297,8 +299,6 @@ form, FORM, returns the new value for *compilation-level*."
 (defun compile-expression (form)
   (let ((compile-expression? t))
     (ps-compile form)))
-
-(defvar *ps-gensym-counter* 0)
 
 (defun ps-gensym (&optional (prefix-or-counter "_JS"))
   (assert (or (stringp prefix-or-counter) (integerp prefix-or-counter)))

--- a/src/js-ir-package.lisp
+++ b/src/js-ir-package.lisp
@@ -107,4 +107,7 @@
    #:funcall
    #:escape
    #:regex
+
+   #:es-class
+   #:=>
    ))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -275,6 +275,11 @@
    #:break
    #:continue
 
+   ;; es6+ stuff
+   #:es-class
+   #:static
+   #:=>
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Deprecated functionality
 


### PR DESCRIPTION
2 Commits:

1. A simple bug. `lambda-wrap`  ends up with a lexical binding for `*ps-gensym-counter*` because the `defvar` appears later in the file.
2. `es-class` and `=>` are the more interesting second commit.

The new `es-class` parenscript form will output ecmascript classes with support for member/static-member assignment from within the body (some of which is post es-2015, but it only appears in the generated code if you use it)

```lisp
(ps:ps
  (es-class HelloWorld ()
    (defun constructor ()
      (format t "hello?"))
    (setf id
	  (=> (x) x))
    (static
     (setf proto foo))))
```

```javascript
class HelloWorld {
    constructor () {
        return format(true, 'hello?');
    }
    id = (x) => {
        return x;
    }
    static proto = foo
};
```